### PR TITLE
Fix syntax error on create_workout_page_widget.dart

### DIFF
--- a/lib/create_workout_page/create_workout_page_widget.dart
+++ b/lib/create_workout_page/create_workout_page_widget.dart
@@ -256,6 +256,8 @@ class _CreateWorkoutPageWidgetState extends State<CreateWorkoutPageWidget> {
                                           : Colors.white,
                                       contentPadding:
                                           const EdgeInsetsDirectional.fromSTEB(
+                                      fillColor: Colors.black, // Set background to black
+                                          contentPadding: const EdgeInsetsDirectional.fromSTEB(
                                               16.0, 20.0, 16.0, 20.0),
                                     ),
                                     style: FlutterFlowTheme.of(context)


### PR DESCRIPTION
Fixed syntax error that was preventing the program from starting.